### PR TITLE
Add prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,21 +4,18 @@
     "ecmaVersion": 6,
     "sourceType": "script"
   },
-  "extends": "airbnb-base",
+  "extends": [
+    "airbnb-base",
+    "prettier"
+  ],
+  "plugins": [
+    "prettier"
+  ],
   "rules": {
-    "brace-style": ["error", "stroustrup"],
-    "max-len": ["warn", {
-      "code": 100,
-      "comments": 80,
-      "ignoreUrls": true,
-      "ignorePattern": "(logger\\.|new Error\\(|new TypeError\\()",
-      "ignoreTrailingComments": true,
-      "tabWidth": 2
-    }],
+    "prettier/prettier": "error",
     "no-param-reassign": "off",
     "no-underscore-dangle": "off",
     "no-warning-comments": "warn",
-    "quotes": ["error", "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
     "require-jsdoc": ["error", {
       "require": {
         "FunctionDeclaration": true,
@@ -26,14 +23,7 @@
         "ClassDeclaration": true
       }
     }],
-    "valid-jsdoc": "error",
-    "comma-dangle": ["error", {
-      "arrays": "always-multiline",
-      "objects": "always-multiline",
-      "imports": "always-multiline",
-      "exports": "always-multiline",
-      "functions": "never"
-    }]
+    "valid-jsdoc": "error"
   },
   "env": {
     "jest": true

--- a/__tests__/Exciter.js
+++ b/__tests__/Exciter.js
@@ -1,15 +1,18 @@
-'use strict';
+"use strict";
 
-const mockdate = require('mockdate');
-const sinon = require('sinon');
-const _ = require('lodash');
-const Exciter = require('../lib/Exciter');
+const mockdate = require("mockdate");
+const sinon = require("sinon");
+const _ = require("lodash");
+const Exciter = require("../lib/Exciter");
 
-const exciter = new Exciter({
-  accessKeyId: 'COOLACCESSKEYID',
-  secretAccessKey: 'SUPERSECRETSHHHH',
-  region: 'us-east-1',
-}, false);
+const exciter = new Exciter(
+  {
+    accessKeyId: "COOLACCESSKEYID",
+    secretAccessKey: "SUPERSECRETSHHHH",
+    region: "us-east-1"
+  },
+  false
+);
 const exciterAllowReject = new Exciter();
 
 beforeAll(() => {
@@ -32,7 +35,7 @@ afterAll(() => {
  */
 function awsPromiseResolve(res) {
   return () => ({
-    promise: () => Promise.resolve(res),
+    promise: () => Promise.resolve(res)
   });
 }
 
@@ -48,74 +51,89 @@ function awsPromiseResolve(res) {
  */
 function awsPromiseReject(err) {
   return () => ({
-    promise: () => Promise.reject(err),
+    promise: () => Promise.reject(err)
   });
 }
 
-test('buildUpdateExpression', () => {
+test("buildUpdateExpression", () => {
   const updateExpression = Exciter.buildUpdateExpression([
-    { name: 'key', value: 'value' },
-    { name: 'thing', value: 'foo' },
-    { name: 'nested_value', path: 'nested.value', value: 'I am nested.' },
-    { name: 'nested_double_value', path: 'nested.double.value', value: 'Yeah? Well I am double nested.' },
+    { name: "key", value: "value" },
+    { name: "thing", value: "foo" },
+    { name: "nested_value", path: "nested.value", value: "I am nested." },
+    {
+      name: "nested_double_value",
+      path: "nested.double.value",
+      value: "Yeah? Well I am double nested."
+    }
   ]);
-  expect(updateExpression).toEqual('SET #key = :key, #thing = :thing, #nested_value_nested.#nested_value_value = :nested_value, #nested_double_value_nested.#nested_double_value_double.#nested_double_value_value = :nested_double_value');
+  expect(updateExpression).toEqual(
+    "SET #key = :key, #thing = :thing, #nested_value_nested.#nested_value_value = :nested_value, #nested_double_value_nested.#nested_double_value_double.#nested_double_value_value = :nested_double_value"
+  );
 });
 
-test('buildExpressionPlaceholdersValue', () => {
+test("buildExpressionPlaceholdersValue", () => {
   const object = [
-    { name: 'key', value: 'value' },
-    { name: 'thing', value: 'foo' },
-    { name: 'video', value: 123 },
-    { name: 'array', value: ['one', 'two'] },
-    { name: 'nested_value', path: 'nested.value', value: 'I am nested.' },
-    { name: 'nested_double_value', path: 'nested.double.value', value: 'Yeah? Well I am double nested.' },
+    { name: "key", value: "value" },
+    { name: "thing", value: "foo" },
+    { name: "video", value: 123 },
+    { name: "array", value: ["one", "two"] },
+    { name: "nested_value", path: "nested.value", value: "I am nested." },
+    {
+      name: "nested_double_value",
+      path: "nested.double.value",
+      value: "Yeah? Well I am double nested."
+    }
   ];
-  const nameExpression = Exciter.buildExpressionPlaceholders(object, ':');
+  const nameExpression = Exciter.buildExpressionPlaceholders(object, ":");
   expect(nameExpression).toEqual({
-    ':key': 'value',
-    ':thing': 'foo',
-    ':video': 123,
-    ':array0': 'one',
-    ':array1': 'two',
-    ':nested_value': 'I am nested.',
-    ':nested_double_value': 'Yeah? Well I am double nested.',
+    ":key": "value",
+    ":thing": "foo",
+    ":video": 123,
+    ":array0": "one",
+    ":array1": "two",
+    ":nested_value": "I am nested.",
+    ":nested_double_value": "Yeah? Well I am double nested."
   });
 });
 
-test('buildExpressionPlaceholdersName', () => {
+test("buildExpressionPlaceholdersName", () => {
   const object = [
-    { name: 'key', value: 'value' },
-    { name: 'thing', value: 'foo' },
-    { name: 'video', value: 123 },
-    { name: 'nested_value', path: 'nested.value', value: 'I am nested.' },
-    { name: 'nested_double_value', path: 'nested.double.value', value: 'Yeah? Well I am double nested.' },
+    { name: "key", value: "value" },
+    { name: "thing", value: "foo" },
+    { name: "video", value: 123 },
+    { name: "nested_value", path: "nested.value", value: "I am nested." },
+    {
+      name: "nested_double_value",
+      path: "nested.double.value",
+      value: "Yeah? Well I am double nested."
+    }
   ];
-  const nameExpression = Exciter.buildExpressionPlaceholders(object, '#');
+  const nameExpression = Exciter.buildExpressionPlaceholders(object, "#");
   expect(nameExpression).toEqual({
-    '#key': 'key',
-    '#thing': 'thing',
-    '#video': 'video',
-    '#nested_value_nested': 'nested',
-    '#nested_value_value': 'value',
-    '#nested_double_value_nested': 'nested',
-    '#nested_double_value_double': 'double',
-    '#nested_double_value_value': 'value',
+    "#key": "key",
+    "#thing": "thing",
+    "#video": "video",
+    "#nested_value_nested": "nested",
+    "#nested_value_value": "value",
+    "#nested_double_value_nested": "nested",
+    "#nested_double_value_double": "double",
+    "#nested_double_value_value": "value"
   });
 });
 
-test('deleteSuccess', (done) => {
+test("deleteSuccess", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
-  sinon.stub(exciter.dynamo, 'delete').callsFake(awsPromiseResolve(pk));
-  return exciter.delete(pk, 'fake')
-    .then((res) => {
+  sinon.stub(exciter.dynamo, "delete").callsFake(awsPromiseResolve(pk));
+  return exciter
+    .delete(pk, "fake")
+    .then(res => {
       expect(res).toEqual(pk);
     })
-    .catch((err) => {
+    .catch(err => {
       expect(err).toBeUndefined();
     })
     .then(() => {
@@ -124,16 +142,19 @@ test('deleteSuccess', (done) => {
     });
 });
 
-test('deleteFailReject', (done) => {
+test("deleteFailReject", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
-  sinon.stub(exciterAllowReject.dynamo, 'delete').callsFake(awsPromiseReject(new Error('Bad thing happened')));
-  return exciterAllowReject.delete(pk, 'fake')
+  sinon
+    .stub(exciterAllowReject.dynamo, "delete")
+    .callsFake(awsPromiseReject(new Error("Bad thing happened")));
+  return exciterAllowReject
+    .delete(pk, "fake")
     .then(() => {
-      expect('Promise should reject if rejectOnFail is true').toEqual(false);
+      expect("Promise should reject if rejectOnFail is true").toEqual(false);
     })
     .catch(() => {
       expect(true).toEqual(true);
@@ -144,13 +165,16 @@ test('deleteFailReject', (done) => {
     });
 });
 
-test('createProxy', (done) => {
+test("createProxy", done => {
   expect.assertions(2);
-  const putSpy = jest.spyOn(exciter, 'put').mockImplementation(() => Promise.resolve());
-  return exciter.create({}, 'table', 'key')
+  const putSpy = jest
+    .spyOn(exciter, "put")
+    .mockImplementation(() => Promise.resolve());
+  return exciter
+    .create({}, "table", "key")
     .then(() => {
       expect(putSpy).toHaveBeenCalledTimes(1);
-      expect(putSpy).toHaveBeenCalledWith({}, 'table', 'key', true);
+      expect(putSpy).toHaveBeenCalledWith({}, "table", "key", true);
     })
     .catch(err => expect(err).toBeUndefined())
     .then(() => {
@@ -159,13 +183,16 @@ test('createProxy', (done) => {
     });
 });
 
-test('updateProxy', (done) => {
+test("updateProxy", done => {
   expect.assertions(2);
-  const patchSpy = jest.spyOn(exciter, 'patch').mockImplementation(() => Promise.resolve());
-  return exciter.update({}, {}, 'table')
+  const patchSpy = jest
+    .spyOn(exciter, "patch")
+    .mockImplementation(() => Promise.resolve());
+  return exciter
+    .update({}, {}, "table")
     .then(() => {
       expect(patchSpy).toHaveBeenCalledTimes(1);
-      expect(patchSpy).toHaveBeenCalledWith({}, {}, 'table');
+      expect(patchSpy).toHaveBeenCalledWith({}, {}, "table");
     })
     .catch(err => expect(err).toBeUndefined())
     .then(() => {
@@ -174,21 +201,24 @@ test('updateProxy', (done) => {
     });
 });
 
-test('putReplaceSuccess', (done) => {
+test("putReplaceSuccess", done => {
   expect.assertions(1);
   const data = {
-    key: 'value',
-    videos: '123-123-123',
-    userId: '123456',
-    uuid: '123-123-123',
-    skipMe: null,
+    key: "value",
+    videos: "123-123-123",
+    userId: "123456",
+    uuid: "123-123-123",
+    skipMe: null
   };
-  const putStub = sinon.stub(exciter.dynamo, 'put').callsFake(awsPromiseResolve(data));
-  return exciter.put(data, 'fake')
-    .then((res) => {
+  const putStub = sinon
+    .stub(exciter.dynamo, "put")
+    .callsFake(awsPromiseResolve(data));
+  return exciter
+    .put(data, "fake")
+    .then(res => {
       sinon.assert.calledWith(putStub, {
-        TableName: 'fake',
-        Item: data,
+        TableName: "fake",
+        Item: data
       });
       expect(res).toEqual(data);
     })
@@ -199,22 +229,25 @@ test('putReplaceSuccess', (done) => {
     });
 });
 
-test('putCreateSuccess', (done) => {
+test("putCreateSuccess", done => {
   expect.assertions(1);
   const data = {
-    key: 'value',
-    videos: '123-123-123',
-    userId: '123456',
-    uuid: '123-123-123',
-    skipMe: null,
+    key: "value",
+    videos: "123-123-123",
+    userId: "123456",
+    uuid: "123-123-123",
+    skipMe: null
   };
-  const putStub = sinon.stub(exciter.dynamo, 'put').callsFake(awsPromiseResolve(data));
-  return exciter.put(data, 'fake', 'userId', true)
-    .then((res) => {
+  const putStub = sinon
+    .stub(exciter.dynamo, "put")
+    .callsFake(awsPromiseResolve(data));
+  return exciter
+    .put(data, "fake", "userId", true)
+    .then(res => {
       sinon.assert.calledWith(putStub, {
-        TableName: 'fake',
+        TableName: "fake",
         Item: data,
-        ConditionExpression: 'attribute_not_exists(userId)',
+        ConditionExpression: "attribute_not_exists(userId)"
       });
       expect(res).toEqual(data);
     })
@@ -225,21 +258,24 @@ test('putCreateSuccess', (done) => {
     });
 });
 
-test('putFailReject', (done) => {
+test("putFailReject", done => {
   expect.assertions(1);
   const data = {
-    key: 'value',
-    videos: '123-123-123',
-    userId: '123456',
-    uuid: '123-123-123',
+    key: "value",
+    videos: "123-123-123",
+    userId: "123456",
+    uuid: "123-123-123"
   };
-  sinon.stub(exciterAllowReject.dynamo, 'put').callsFake(awsPromiseReject(new Error('Something bad happened!')));
-  return exciterAllowReject.put(data, 'fake')
+  sinon
+    .stub(exciterAllowReject.dynamo, "put")
+    .callsFake(awsPromiseReject(new Error("Something bad happened!")));
+  return exciterAllowReject
+    .put(data, "fake")
     .then(() => {
-      expect('Promise should reject if rejectOnFail is true').toEqual(false);
+      expect("Promise should reject if rejectOnFail is true").toEqual(false);
     })
-    .catch((e) => {
-      expect(e.message).toEqual('Something bad happened!');
+    .catch(e => {
+      expect(e.message).toEqual("Something bad happened!");
     })
     .then(() => {
       exciterAllowReject.dynamo.put.restore();
@@ -247,36 +283,43 @@ test('putFailReject', (done) => {
     });
 });
 
-test('patchSuccess', (done) => {
+test("patchSuccess", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
   const data = {
-    key: 'value',
-    videos: '123-123-123',
-    userId: '123456',
-    uuid: '123-123-123',
-    iAmAMap: { iAmAlsoAMap: { iShouldntGoAway: true } },
+    key: "value",
+    videos: "123-123-123",
+    userId: "123456",
+    uuid: "123-123-123",
+    iAmAMap: { iAmAlsoAMap: { iShouldntGoAway: true } }
   };
-  const updateStub = sinon.stub(exciter.dynamo, 'update').callsFake(awsPromiseResolve(pk));
-  return exciter.patch(data, pk, 'fake')
-    .then((res) => {
+  const updateStub = sinon
+    .stub(exciter.dynamo, "update")
+    .callsFake(awsPromiseResolve(pk));
+  return exciter
+    .patch(data, pk, "fake")
+    .then(res => {
       sinon.assert.calledWith(updateStub, {
-        TableName: 'fake',
+        TableName: "fake",
         Key: pk,
-        UpdateExpression: 'SET #key = :key, #videos = :videos, #iAmAMap = :iAmAMap',
-        ExpressionAttributeNames: { '#key': 'key', '#videos': 'videos', '#iAmAMap': 'iAmAMap' },
-        ExpressionAttributeValues: {
-          ':key': data.key,
-          ':videos': data.videos,
-          ':iAmAMap': data.iAmAMap,
+        UpdateExpression: "SET #key = :key, #videos = :videos, #iAmAMap = :iAmAMap",
+        ExpressionAttributeNames: {
+          "#key": "key",
+          "#videos": "videos",
+          "#iAmAMap": "iAmAMap"
         },
+        ExpressionAttributeValues: {
+          ":key": data.key,
+          ":videos": data.videos,
+          ":iAmAMap": data.iAmAMap
+        }
       });
       expect(res).toEqual(pk);
     })
-    .catch((err) => {
+    .catch(err => {
       expect(err).toBeUndefined();
     })
     .then(() => {
@@ -285,25 +328,28 @@ test('patchSuccess', (done) => {
     });
 });
 
-test('patchFailReject', (done) => {
+test("patchFailReject", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
   const data = {
-    key: 'value',
-    videos: '123-123-123',
-    userId: '123456',
-    uuid: '123-123-123',
+    key: "value",
+    videos: "123-123-123",
+    userId: "123456",
+    uuid: "123-123-123"
   };
-  sinon.stub(exciterAllowReject.dynamo, 'update').callsFake(awsPromiseReject(new Error('Something bad happened!')));
-  return exciterAllowReject.patch(data, pk, 'fake', true)
+  sinon
+    .stub(exciterAllowReject.dynamo, "update")
+    .callsFake(awsPromiseReject(new Error("Something bad happened!")));
+  return exciterAllowReject
+    .patch(data, pk, "fake", true)
     .then(() => {
-      expect('Promise should reject if rejectOnFail is true').toEqual(false);
+      expect("Promise should reject if rejectOnFail is true").toEqual(false);
     })
-    .catch((e) => {
-      expect(e.message).toEqual('Something bad happened!');
+    .catch(e => {
+      expect(e.message).toEqual("Something bad happened!");
     })
     .then(() => {
       exciterAllowReject.dynamo.update.restore();
@@ -311,19 +357,20 @@ test('patchFailReject', (done) => {
     });
 });
 
-test('load', (done) => {
+test("load", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
-  const expected = { some: 'ExpectedThing' };
-  sinon.stub(exciter.dynamo, 'get').callsFake(awsPromiseResolve(expected));
-  return exciter.load(pk, 'fake')
-    .then((res) => {
+  const expected = { some: "ExpectedThing" };
+  sinon.stub(exciter.dynamo, "get").callsFake(awsPromiseResolve(expected));
+  return exciter
+    .load(pk, "fake")
+    .then(res => {
       expect(res).toEqual(expected);
     })
-    .catch((err) => {
+    .catch(err => {
       expect(err).toBeUndefined();
     })
     .then(() => {
@@ -332,27 +379,31 @@ test('load', (done) => {
     });
 });
 
-test('loadError', (done) => {
+test("loadError", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
-  const expectedMessage = 'Dynamo had a sad.';
-  sinon.stub(exciterAllowReject.dynamo, 'get').callsFake(awsPromiseReject(new Error(expectedMessage)));
-  return exciterAllowReject.load(pk, 'fake')
+  const expectedMessage = "Dynamo had a sad.";
+  sinon
+    .stub(exciterAllowReject.dynamo, "get")
+    .callsFake(awsPromiseReject(new Error(expectedMessage)));
+  return exciterAllowReject
+    .load(pk, "fake")
     .then(res => expect(res).toBeUndefined())
-    .catch((err) => {
+    .catch(err => {
       expect(err.message).toEqual(expectedMessage);
       exciterAllowReject.dynamo.get.restore();
       done();
     });
 });
 
-test('catchHandler', (done) => {
+test("catchHandler", done => {
   expect.assertions(2);
-  const error = new Error('This is bad.');
-  return exciter.catchHandler(error)
+  const error = new Error("This is bad.");
+  return exciter
+    .catchHandler(error)
     .catch(err => expect(err).toBeUndefined())
     .then(() => {
       expect(true).toEqual(true);
@@ -363,31 +414,33 @@ test('catchHandler', (done) => {
     .then(done);
 });
 
-
-test('querySuccess', (done) => {
+test("querySuccess", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
-  const expected = { expected: 'thing' };
-  const stub = sinon.stub(exciterAllowReject.dynamo, 'query').callsFake(awsPromiseResolve(expected));
-  return exciterAllowReject.query(pk, 'fake')
-    .then((res) => {
+  const expected = { expected: "thing" };
+  const stub = sinon
+    .stub(exciterAllowReject.dynamo, "query")
+    .callsFake(awsPromiseResolve(expected));
+  return exciterAllowReject
+    .query(pk, "fake")
+    .then(res => {
       expect(res).toEqual(expected);
       sinon.assert.calledWith(stub, {
-        KeyConditionExpression: '((#userId = :userId) AND (#uuid = :uuid))',
+        KeyConditionExpression: "((#userId = :userId) AND (#uuid = :uuid))",
         ExpressionAttributeValues: {
-          ':userId': '123456',
-          ':uuid': '123-123-123',
+          ":userId": "123456",
+          ":uuid": "123-123-123"
         },
         ExpressionAttributeNames: {
-          '#userId': 'userId',
-          '#uuid': 'uuid',
+          "#userId": "userId",
+          "#uuid": "uuid"
         },
-        TableName: 'fake',
+        TableName: "fake",
         Limit: 10,
-        ScanIndexForward: true,
+        ScanIndexForward: true
       });
     })
     .catch(err => expect(err).toBeUndefined())
@@ -397,15 +450,18 @@ test('querySuccess', (done) => {
     });
 });
 
-test('queryError', (done) => {
+test("queryError", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
-  const expectedMessage = 'Dynamo had a sad.';
-  sinon.stub(exciterAllowReject.dynamo, 'query').callsFake(awsPromiseReject(new Error(expectedMessage)));
-  return exciterAllowReject.query(pk, 'fake')
+  const expectedMessage = "Dynamo had a sad.";
+  sinon
+    .stub(exciterAllowReject.dynamo, "query")
+    .callsFake(awsPromiseReject(new Error(expectedMessage)));
+  return exciterAllowReject
+    .query(pk, "fake")
     .catch(err => expect(err.message).toEqual(expectedMessage))
     .then(() => {
       exciterAllowReject.dynamo.query.restore();
@@ -413,63 +469,66 @@ test('queryError', (done) => {
     });
 });
 
-test('queryNoUngroupped', (done) => {
+test("queryNoUngroupped", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
   const filters = {
     andGroup: {
       group: {
-        conjunction: 'OR',
-      },
+        conjunction: "OR"
+      }
     },
     firstGroupedFilter: {
       condition: {
-        path: 'first',
-        value: 'one',
-        memberOf: 'andGroup',
-      },
+        path: "first",
+        value: "one",
+        memberOf: "andGroup"
+      }
     },
     secondGroupedFilter: {
       condition: {
-        path: 'second',
-        value: 'two',
-        memberOf: 'andGroup',
-      },
-    },
+        path: "second",
+        value: "two",
+        memberOf: "andGroup"
+      }
+    }
   };
-  const expected = { expected: 'thing' };
+  const expected = { expected: "thing" };
   const dynamoQuery = {
     startKey: pk,
     rawFilters: filters,
-    select: 'ALL_ATTRIBUTES',
+    select: "ALL_ATTRIBUTES"
   };
-  const stub = sinon.stub(exciterAllowReject.dynamo, 'query').callsFake(awsPromiseResolve(expected));
-  return exciterAllowReject.query(pk, 'fake', dynamoQuery)
-    .then((res) => {
+  const stub = sinon
+    .stub(exciterAllowReject.dynamo, "query")
+    .callsFake(awsPromiseResolve(expected));
+  return exciterAllowReject
+    .query(pk, "fake", dynamoQuery)
+    .then(res => {
       expect(res).toEqual(expected);
       sinon.assert.calledWith(stub, {
-        KeyConditionExpression: '((#userId = :userId) AND (#uuid = :uuid))',
-        FilterExpression: '((#firstGroupedFilter_first = :firstGroupedFilter) OR (#secondGroupedFilter_second = :secondGroupedFilter))',
+        KeyConditionExpression: "((#userId = :userId) AND (#uuid = :uuid))",
+        FilterExpression: "((#firstGroupedFilter_first = :firstGroupedFilter) OR (#secondGroupedFilter_second = :secondGroupedFilter))",
         ExpressionAttributeValues: {
-          ':userId': '123456',
-          ':uuid': '123-123-123',
-          ':firstGroupedFilter': 'one',
-          ':secondGroupedFilter': 'two',
+          ":userId": "123456",
+          ":uuid": "123-123-123",
+          ":firstGroupedFilter": "one",
+          ":secondGroupedFilter": "two"
         },
         ExpressionAttributeNames: {
-          '#userId': 'userId',
-          '#uuid': 'uuid',
-          '#firstGroupedFilter_first': 'first',
-          '#secondGroupedFilter_second': 'second',
+          "#userId": "userId",
+          "#uuid": "uuid",
+          "#firstGroupedFilter_first": "first",
+          "#secondGroupedFilter_second": "second"
         },
         ExclusiveStartKey: pk,
-        Select: 'ALL_ATTRIBUTES',
-        TableName: 'fake',
+        Select: "ALL_ATTRIBUTES",
+        TableName: "fake",
         Limit: 10,
-        ScanIndexForward: true,
+        ScanIndexForward: true
       });
     })
     .catch(err => expect(err).toBeUndefined())
@@ -479,45 +538,46 @@ test('queryNoUngroupped', (done) => {
     });
 });
 
-test('querySort', (done) => {
+test("querySort", done => {
   expect.assertions(4);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
-  const expected = { expected: 'thing', Items: [{ one: 'one' }, { two: 'two' }] };
-  const stub = sinon.stub(exciterAllowReject.dynamo, 'query').callsFake(awsPromiseResolve(expected));
-  const combos = [
-    [true, false],
-    [false, true],
-    [true, true],
-    [false, false],
-  ];
-  const testCombos = combos.map((combo) => {
+  const expected = {
+    expected: "thing",
+    Items: [{ one: "one" }, { two: "two" }]
+  };
+  const stub = sinon
+    .stub(exciterAllowReject.dynamo, "query")
+    .callsFake(awsPromiseResolve(expected));
+  const combos = [[true, false], [false, true], [true, true], [false, false]];
+  const testCombos = combos.map(combo => {
     const query = {
       pageForward: combo[0],
-      sortAscending: combo[1],
+      sortAscending: combo[1]
     };
-    return exciterAllowReject.query(pk, 'fake', query)
-      .then((res) => {
-        expect(res.Items[0]).toEqual(expected.Items[query.pageForward ? 0 : 1]);
-        sinon.assert.calledWith(stub, {
-          KeyConditionExpression: '((#userId = :userId) AND (#uuid = :uuid))',
-          ExpressionAttributeValues: {
-            ':userId': '123456',
-            ':uuid': '123-123-123',
-          },
-          ExpressionAttributeNames: {
-            '#userId': 'userId',
-            '#uuid': 'uuid',
-          },
-          TableName: 'fake',
-          Limit: 10,
-          // The sortAscending parameter should essentially reverse the
-          // pageForward param.
-          ScanIndexForward: query.sortAscending ? query.pageForward : !query.pageForward,
-        });
+    return exciterAllowReject.query(pk, "fake", query).then(res => {
+      expect(res.Items[0]).toEqual(expected.Items[query.pageForward ? 0 : 1]);
+      sinon.assert.calledWith(stub, {
+        KeyConditionExpression: "((#userId = :userId) AND (#uuid = :uuid))",
+        ExpressionAttributeValues: {
+          ":userId": "123456",
+          ":uuid": "123-123-123"
+        },
+        ExpressionAttributeNames: {
+          "#userId": "userId",
+          "#uuid": "uuid"
+        },
+        TableName: "fake",
+        Limit: 10,
+        // The sortAscending parameter should essentially reverse the
+        // pageForward param.
+        ScanIndexForward: query.sortAscending
+          ? query.pageForward
+          : !query.pageForward
       });
+    });
   });
 
   return Promise.all(testCombos)
@@ -528,38 +588,41 @@ test('querySort', (done) => {
     });
 });
 
-test('queryLastPageForward', (done) => {
+test("queryLastPageForward", done => {
   expect.assertions(2);
   const pk = {
-    userId: '123456',
+    userId: "123456"
   };
   // What the response from dynamo would be if you had paged forward to the
   // last page.
   const dynamoResponseForward = {
     Items: [
-      { one: 'one' },
-      { two: 'two' },
-      { three: 'three' },
-      { four: 'four' },
-      { five: 'five' },
+      { one: "one" },
+      { two: "two" },
+      { three: "three" },
+      { four: "four" },
+      { five: "five" }
     ],
-    LastEvaluatedKey: { shouldBe: 'deleted' },
+    LastEvaluatedKey: { shouldBe: "deleted" }
   };
   const dynamoResponseReversed = {
     Items: [
-      { five: 'five' },
-      { four: 'four' },
-      { three: 'three' },
-      { two: 'two' },
-      { one: 'one' },
+      { five: "five" },
+      { four: "four" },
+      { three: "three" },
+      { two: "two" },
+      { one: "one" }
     ],
-    LastEvaluatedKey: { shouldBe: 'deleted' },
+    LastEvaluatedKey: { shouldBe: "deleted" }
   };
-  const query = { startKey: 'last', limit: 5 };
-  sinon.stub(exciterAllowReject.dynamo, 'query').callsFake(awsPromiseResolve(dynamoResponseReversed));
-  sinon.stub(exciterAllowReject, 'getTotalCount').resolves(103);
-  return exciterAllowReject.query(pk, 'fake', query)
-    .then((res) => {
+  const query = { startKey: "last", limit: 5 };
+  sinon
+    .stub(exciterAllowReject.dynamo, "query")
+    .callsFake(awsPromiseResolve(dynamoResponseReversed));
+  sinon.stub(exciterAllowReject, "getTotalCount").resolves(103);
+  return exciterAllowReject
+    .query(pk, "fake", query)
+    .then(res => {
       expect(res.Items).toEqual(dynamoResponseForward.Items.slice(2));
       expect(res.LastEvaluatedKey).toBeUndefined();
     })
@@ -571,40 +634,45 @@ test('queryLastPageForward', (done) => {
     });
 });
 
-test('queryLastPageBackwards', (done) => {
+test("queryLastPageBackwards", done => {
   expect.assertions(2);
   const pk = {
-    userId: '123456',
+    userId: "123456"
   };
   // What the response from dynamo would be if you had paged backward to the
   // last page.
   const dynamoResponseReversed = {
     Items: [
-      { five: 'five' },
-      { four: 'four' },
-      { three: 'three' },
-      { two: 'two' },
-      { one: 'one' },
+      { five: "five" },
+      { four: "four" },
+      { three: "three" },
+      { two: "two" },
+      { one: "one" }
     ],
-    LastEvaluatedKey: { shouldBe: 'deleted' },
+    LastEvaluatedKey: { shouldBe: "deleted" }
   };
   const dynamoResponseForward = {
     Items: [
-      { one: 'one' },
-      { two: 'two' },
-      { three: 'three' },
-      { four: 'four' },
-      { five: 'five' },
+      { one: "one" },
+      { two: "two" },
+      { three: "three" },
+      { four: "four" },
+      { five: "five" }
     ],
-    LastEvaluatedKey: { shouldBe: 'deleted' },
+    LastEvaluatedKey: { shouldBe: "deleted" }
   };
-  const query = { startKey: 'last', limit: 5, pageForward: false };
-  sinon.stub(exciterAllowReject.dynamo, 'query').callsFake(awsPromiseResolve(dynamoResponseForward));
-  sinon.stub(exciterAllowReject, 'getTotalCount').resolves(103);
+  const query = { startKey: "last", limit: 5, pageForward: false };
+  sinon
+    .stub(exciterAllowReject.dynamo, "query")
+    .callsFake(awsPromiseResolve(dynamoResponseForward));
+  sinon.stub(exciterAllowReject, "getTotalCount").resolves(103);
 
-  return exciterAllowReject.query(pk, 'fake', query)
-    .then((res) => {
-      expect(res.Items).toEqual([].concat(dynamoResponseReversed.Items.slice(2)));
+  return exciterAllowReject
+    .query(pk, "fake", query)
+    .then(res => {
+      expect(res.Items).toEqual(
+        [].concat(dynamoResponseReversed.Items.slice(2))
+      );
       expect(res.LastEvaluatedKey).toBeUndefined();
     })
     .catch(err => expect(err).toBeUndefined())
@@ -615,92 +683,95 @@ test('queryLastPageBackwards', (done) => {
     });
 });
 
-test('queryKitchenSink', (done) => {
+test("queryKitchenSink", done => {
   expect.assertions(1);
   const pk = {
-    userId: '123456',
-    uuid: '123-123-123',
+    userId: "123456",
+    uuid: "123-123-123"
   };
   const filters = {
     emptyGroup: {
       group: {
-        conjunction: 'AND',
-      },
+        conjunction: "AND"
+      }
     },
     andGroup: {
       group: {
-        conjunction: 'OR',
-      },
+        conjunction: "OR"
+      }
     },
     firstGroupedFilter: {
       condition: {
-        path: 'first',
-        value: 'one',
-        memberOf: 'andGroup',
-      },
+        path: "first",
+        value: "one",
+        memberOf: "andGroup"
+      }
     },
     secondGroupedFilter: {
       condition: {
-        path: 'second',
-        value: 'two',
-        memberOf: 'andGroup',
-      },
+        path: "second",
+        value: "two",
+        memberOf: "andGroup"
+      }
     },
     someFilter: {
       condition: {
-        path: 'some',
-        value: 'filter',
-        operator: '<',
-      },
+        path: "some",
+        value: "filter",
+        operator: "<"
+      }
     },
     nestedFilter: {
       condition: {
-        path: 'some.nested.thing',
-        value: 'egg',
-      },
-    },
+        path: "some.nested.thing",
+        value: "egg"
+      }
+    }
   };
-  const expected = { expected: 'thing' };
+  const expected = { expected: "thing" };
   const dynamoQuery = {
     startKey: pk,
     rawFilters: filters,
-    select: 'ALL_ATTRIBUTES',
+    select: "ALL_ATTRIBUTES",
     includeTotal: true,
-    index: 'sorted-index',
+    index: "sorted-index"
   };
-  const stub = sinon.stub(exciterAllowReject.dynamo, 'query').callsFake(awsPromiseResolve(expected));
-  sinon.stub(exciterAllowReject, 'getTotalCount').resolves(100);
-  return exciterAllowReject.query(pk, 'fake', dynamoQuery)
-    .then((res) => {
+  const stub = sinon
+    .stub(exciterAllowReject.dynamo, "query")
+    .callsFake(awsPromiseResolve(expected));
+  sinon.stub(exciterAllowReject, "getTotalCount").resolves(100);
+  return exciterAllowReject
+    .query(pk, "fake", dynamoQuery)
+    .then(res => {
       expected.totalCount = 100;
       expect(res).toEqual(expected);
       sinon.assert.calledWith(stub, {
-        KeyConditionExpression: '((#userId = :userId) AND (#uuid = :uuid))',
-        FilterExpression: '((#firstGroupedFilter_first = :firstGroupedFilter) OR (#secondGroupedFilter_second = :secondGroupedFilter)) AND ((#someFilter_some < :someFilter) AND (#nestedFilter_some.#nestedFilter_nested.#nestedFilter_thing = :nestedFilter))',
+        KeyConditionExpression: "((#userId = :userId) AND (#uuid = :uuid))",
+        FilterExpression: "((#firstGroupedFilter_first = :firstGroupedFilter) OR (#secondGroupedFilter_second = :secondGroupedFilter)) AND ((#someFilter_some < :someFilter) AND (#nestedFilter_some.#nestedFilter_nested.#nestedFilter_thing = :nestedFilter))",
         ExpressionAttributeValues: {
-          ':userId': '123456',
-          ':uuid': '123-123-123',
-          ':someFilter': 'filter',
-          ':nestedFilter': 'egg',
-          ':firstGroupedFilter': 'one',
-          ':secondGroupedFilter': 'two',
+          ":userId": "123456",
+          ":uuid": "123-123-123",
+          ":someFilter": "filter",
+          ":nestedFilter": "egg",
+          ":firstGroupedFilter": "one",
+          ":secondGroupedFilter": "two"
         },
         ExpressionAttributeNames: {
-          '#userId': 'userId',
-          '#uuid': 'uuid',
-          '#firstGroupedFilter_first': 'first',
-          '#secondGroupedFilter_second': 'second',
-          '#someFilter_some': 'some',
-          '#nestedFilter_some': 'some',
-          '#nestedFilter_nested': 'nested',
-          '#nestedFilter_thing': 'thing',
+          "#userId": "userId",
+          "#uuid": "uuid",
+          "#firstGroupedFilter_first": "first",
+          "#secondGroupedFilter_second": "second",
+          "#someFilter_some": "some",
+          "#nestedFilter_some": "some",
+          "#nestedFilter_nested": "nested",
+          "#nestedFilter_thing": "thing"
         },
         ExclusiveStartKey: pk,
-        Select: 'ALL_ATTRIBUTES',
-        TableName: 'fake',
-        IndexName: 'sorted-index',
+        Select: "ALL_ATTRIBUTES",
+        TableName: "fake",
+        IndexName: "sorted-index",
         Limit: 10,
-        ScanIndexForward: true,
+        ScanIndexForward: true
       });
     })
     .catch(err => expect(err).toBeUndefined())
@@ -711,264 +782,312 @@ test('queryKitchenSink', (done) => {
     });
 });
 
-test('normalizeGroup', (done) => {
+test("normalizeGroup", done => {
   expect.assertions(1);
   const data = [
-    ['defaultConjunction', {}],
-    ['andConjunction', { conjunction: 'AND' }],
-    ['orConjunction', { conjunction: 'OR' }],
+    ["defaultConjunction", {}],
+    ["andConjunction", { conjunction: "AND" }],
+    ["orConjunction", { conjunction: "OR" }]
   ];
   const expected = [
-    { name: 'defaultConjunction', conjunction: 'AND' },
-    { name: 'andConjunction', conjunction: 'AND' },
-    { name: 'orConjunction', conjunction: 'OR' },
+    { name: "defaultConjunction", conjunction: "AND" },
+    { name: "andConjunction", conjunction: "AND" },
+    { name: "orConjunction", conjunction: "OR" }
   ];
   const res = data.map(args => Exciter.normalizeGroup(args[1], args[0]));
   expect(res).toEqual(expected);
   done();
 });
 
-test('normalizeGroupUnsupported', (done) => {
+test("normalizeGroupUnsupported", done => {
   expect.assertions(1);
   try {
-    Exciter.normalizeGroup({ conjunction: 'junctionwhatsyourfunction' }, 'unsupportedConjunction');
-  }
-  catch (err) {
-    expect(err.message).toEqual('Unsupported group conjunction: junctionwhatsyourfunction. Allowed conjunctions: AND, OR.');
+    Exciter.normalizeGroup(
+      { conjunction: "junctionwhatsyourfunction" },
+      "unsupportedConjunction"
+    );
+  } catch (err) {
+    expect(err.message).toEqual(
+      "Unsupported group conjunction: junctionwhatsyourfunction. Allowed conjunctions: AND, OR."
+    );
     done();
   }
 });
 
-test('normalizeDataValues', (done) => {
+test("normalizeDataValues", done => {
   expect.assertions(1);
   const data = {
-    id: '123',
+    id: "123",
     attributes: {
-      userId: '345',
-      nestedMap: { someOther: 'thing' },
+      userId: "345",
+      nestedMap: { someOther: "thing" }
     },
-    skipMe: null,
+    skipMe: null
   };
   const expected = [
-    { name: 'id', value: '123' },
-    { name: 'attributes', value: { userId: '345', nestedMap: { someOther: 'thing' } } },
+    { name: "id", value: "123" },
+    {
+      name: "attributes",
+      value: { userId: "345", nestedMap: { someOther: "thing" } }
+    }
   ];
   expect(Exciter.normalizeDataValues(data)).toEqual(expected);
   done();
 });
 
-test('normalizeExpressionAttribute', (done) => {
+test("normalizeExpressionAttribute", done => {
   expect.assertions(1);
   const data = {
-    some: 'simple value',
+    some: "simple value",
     someOther: {
-      value: 'more complex value',
-    },
+      value: "more complex value"
+    }
   };
   const expected = [
-    { name: 'some', value: 'simple value' },
-    { name: 'someOther', value: 'more complex value' },
+    { name: "some", value: "simple value" },
+    { name: "someOther", value: "more complex value" }
   ];
-  const res = Object.keys(data)
-    .map(name => Exciter.normalizeExpressionAttribute(data[name], name));
+  const res = Object.keys(data).map(name =>
+    Exciter.normalizeExpressionAttribute(data[name], name)
+  );
   expect(res).toEqual(expected);
   done();
 });
 
-test('normalizeExpressionAttributeNoName', (done) => {
+test("normalizeExpressionAttributeNoName", done => {
   expect.assertions(1);
   try {
     Exciter.normalizeExpressionAttribute({});
-  }
-  catch (err) {
-    expect(err.message).toEqual('Attribute is missing a name.');
+  } catch (err) {
+    expect(err.message).toEqual("Attribute is missing a name.");
   }
   done();
 });
 
-test('normalizeExpressionAttributeNoValue', (done) => {
+test("normalizeExpressionAttributeNoValue", done => {
   expect.assertions(2);
   try {
-    Exciter.normalizeExpressionAttribute(null, 'nullValueSimple');
-  }
-  catch (err) {
-    expect(err.message).toEqual('Attribute "nullValueSimple" is missing a value.');
+    Exciter.normalizeExpressionAttribute(null, "nullValueSimple");
+  } catch (err) {
+    expect(err.message).toEqual(
+      'Attribute "nullValueSimple" is missing a value.'
+    );
   }
   try {
-    Exciter.normalizeExpressionAttribute({ value: null }, 'nullValueObject');
-  }
-  catch (err) {
-    expect(err.message).toEqual('Attribute "nullValueObject" is missing a value.');
+    Exciter.normalizeExpressionAttribute({ value: null }, "nullValueObject");
+  } catch (err) {
+    expect(err.message).toEqual(
+      'Attribute "nullValueObject" is missing a value.'
+    );
   }
   done();
 });
 
-test('normalizeCondition', (done) => {
+test("normalizeCondition", done => {
   expect.assertions(1);
   const data = [
-    ['defaultOperator', { value: 'equals' }],
-    ['allProps', { name: 'overriddenName', path: 'nested.value', operator: 'between', value: [1, 2, 3], memberOf: 'someGroup', negate: 1 }],
-    ['disallowedProps', { you: 'cannot', see: 'any of', these: 'properties', value: 'you can see me' }],
+    ["defaultOperator", { value: "equals" }],
+    [
+      "allProps",
+      {
+        name: "overriddenName",
+        path: "nested.value",
+        operator: "between",
+        value: [1, 2, 3],
+        memberOf: "someGroup",
+        negate: 1
+      }
+    ],
+    [
+      "disallowedProps",
+      {
+        you: "cannot",
+        see: "any of",
+        these: "properties",
+        value: "you can see me"
+      }
+    ]
   ];
   const expected = [
-    { name: 'defaultOperator', value: 'equals', operator: '=' },
-    { name: 'overriddenName', path: 'nested.value', operator: 'between', value: [1, 2, 3], memberOf: 'someGroup', negate: 1 },
-    { name: 'disallowedProps', value: 'you can see me', operator: '=' },
+    { name: "defaultOperator", value: "equals", operator: "=" },
+    {
+      name: "overriddenName",
+      path: "nested.value",
+      operator: "between",
+      value: [1, 2, 3],
+      memberOf: "someGroup",
+      negate: 1
+    },
+    { name: "disallowedProps", value: "you can see me", operator: "=" }
   ];
   const res = data.map(args => Exciter.normalizeCondition(args[1], args[0]));
   expect(res).toEqual(expected);
   done();
 });
 
-test('buildConditionExpressionSimple', (done) => {
+test("buildConditionExpressionSimple", done => {
   expect.assertions(1);
-  const data = ['=', '<', '>', '<=', '>=', '!=', 'contains', 'startswith'].map(op => ({
+  const data = [
+    "=",
+    "<",
+    ">",
+    "<=",
+    ">=",
+    "!=",
+    "contains",
+    "startswith"
+  ].map(op => ({
     name: `prop${op}`,
     operator: op,
-    value: 'value',
+    value: "value"
   }));
   let expected = [
-    '(#prop= = :prop=)',
-    '(#prop< < :prop<)',
-    '(#prop> > :prop>)',
-    '(#prop<= <= :prop<=)',
-    '(#prop>= >= :prop>=)',
-    '(NOT #prop!= = :prop!=)',
-    '(contains(#propcontains, :propcontains))',
-    '(begins_with(#propstartswith, :propstartswith))',
-  ].join(' AND ');
+    "(#prop= = :prop=)",
+    "(#prop< < :prop<)",
+    "(#prop> > :prop>)",
+    "(#prop<= <= :prop<=)",
+    "(#prop>= >= :prop>=)",
+    "(NOT #prop!= = :prop!=)",
+    "(contains(#propcontains, :propcontains))",
+    "(begins_with(#propstartswith, :propstartswith))"
+  ].join(" AND ");
   expected = `(${expected})`;
   const expression = Exciter.buildConditionExpression(data);
   expect(expression).toEqual(expected);
   done();
 });
 
-test('buildConditionExpressionArray', (done) => {
+test("buildConditionExpressionArray", done => {
   expect.assertions(2);
-  const data = ['in', 'notin', 'between'].map(op => ({
+  const data = ["in", "notin", "between"].map(op => ({
     name: `prop${op}`,
     operator: op,
-    value: ['one', 'two'],
+    value: ["one", "two"]
   }));
   let expected = [
-    '(#propin IN (:propin0, :propin1))',
-    '(NOT #propnotin IN (:propnotin0, :propnotin1))',
-    '(#propbetween BETWEEN :propbetween0 AND :propbetween1)',
-  ].join(' OR ');
+    "(#propin IN (:propin0, :propin1))",
+    "(NOT #propnotin IN (:propnotin0, :propnotin1))",
+    "(#propbetween BETWEEN :propbetween0 AND :propbetween1)"
+  ].join(" OR ");
   expected = `(${expected})`;
-  const expression = Exciter.buildConditionExpression(data, 'OR');
+  const expression = Exciter.buildConditionExpression(data, "OR");
   expect(expression).toEqual(expected);
 
-  const bad = [
-    { name: 'bad', operator: 'in', value: 'I\'m not an array!' },
-  ];
+  const bad = [{ name: "bad", operator: "in", value: "I'm not an array!" }];
   try {
     Exciter.buildConditionExpression(bad);
-  }
-  catch (err) {
-    expect(err.message).toEqual('Value must be an array when using the "in" operator.');
+  } catch (err) {
+    expect(err.message).toEqual(
+      'Value must be an array when using the "in" operator.'
+    );
     done();
   }
 });
 
-test('buildConditionExpressionExists', (done) => {
+test("buildConditionExpressionExists", done => {
   expect.assertions(1);
   const data = [
     {
-      name: 'yup',
-      path: 'does.exist',
-      operator: 'exists',
-      value: 1,
+      name: "yup",
+      path: "does.exist",
+      operator: "exists",
+      value: 1
     },
     {
-      name: 'nope',
-      path: 'does.not.exist',
-      operator: 'exists',
-      value: 0,
-    },
+      name: "nope",
+      path: "does.not.exist",
+      operator: "exists",
+      value: 0
+    }
   ];
-  const expected = '((attribute_exists(#yup_does.#yup_exist)) AND (attribute_not_exists(#nope_does.#nope_not.#nope_exist)))';
+  const expected =
+    "((attribute_exists(#yup_does.#yup_exist)) AND (attribute_not_exists(#nope_does.#nope_not.#nope_exist)))";
   const expression = Exciter.buildConditionExpression(data);
   expect(expression).toEqual(expected);
   done();
 });
 
-test('buildConditionExpressionBadOperator', (done) => {
+test("buildConditionExpressionBadOperator", done => {
   expect.assertions(1);
   try {
-    Exciter.buildConditionExpression([{ name: 'bad', operator: 'bad', value: 'bad' }]);
-  }
-  catch (err) {
-    expect(err.message).toEqual('Unsupported operator: bad');
+    Exciter.buildConditionExpression([
+      { name: "bad", operator: "bad", value: "bad" }
+    ]);
+  } catch (err) {
+    expect(err.message).toEqual("Unsupported operator: bad");
     done();
   }
 });
 
-test('buildConditionExpressionNegate', (done) => {
+test("buildConditionExpressionNegate", done => {
   expect.assertions(1);
-  const expected = '(NOT #negated = :negated)';
-  const expression = Exciter.buildConditionExpression([{ name: 'negated', operator: '=', value: 'thisisnottrue', negate: true }]);
+  const expected = "(NOT #negated = :negated)";
+  const expression = Exciter.buildConditionExpression([
+    { name: "negated", operator: "=", value: "thisisnottrue", negate: true }
+  ]);
   expect(expression).toEqual(expected);
   done();
 });
 
-test('getTotalCount', (done) => {
+test("getTotalCount", done => {
   expect.assertions(4);
   const expected = {
     Count: 15,
     LastEvaluatedKey: {
-      userId: '12345',
-      uuid: '123-123-123',
-    },
+      userId: "12345",
+      uuid: "123-123-123"
+    }
   };
   const queryParams = {
-    Select: 'COUNT',
+    Select: "COUNT",
     ExclusiveStartKey: {
-      userId: '12345',
-      uuid: '123-123-123',
+      userId: "12345",
+      uuid: "123-123-123"
     },
-    Limit: 10,
+    Limit: 10
   };
   let called = 0;
-  sinon.stub(exciterAllowReject.dynamo, 'query').callsFake((params) => {
+  sinon.stub(exciterAllowReject.dynamo, "query").callsFake(params => {
     called += 1;
     if (called === 1) {
-      expect(params).toEqual(_.omit(queryParams, ['Limit', 'ExclusiveStartKey']));
-    }
-    else {
-      expect(params).toEqual(_.omit(queryParams, ['Limit']));
+      expect(params).toEqual(
+        _.omit(queryParams, ["Limit", "ExclusiveStartKey"])
+      );
+    } else {
+      expect(params).toEqual(_.omit(queryParams, ["Limit"]));
       delete expected.LastEvaluatedKey;
     }
     return {
-      promise: () => Promise.resolve(expected),
+      promise: () => Promise.resolve(expected)
     };
   });
 
-  return exciterAllowReject.getTotalCount(_.omit(queryParams, ['Select']))
-  .then((total) => {
-    expect(total).toEqual(30);
-    expect(called).toEqual(2);
-  })
-  .catch(err => expect(err).toBeUndefined())
-  .then(() => {
-    exciterAllowReject.dynamo.query.restore();
-    done();
-  });
+  return exciterAllowReject
+    .getTotalCount(_.omit(queryParams, ["Select"]))
+    .then(total => {
+      expect(total).toEqual(30);
+      expect(called).toEqual(2);
+    })
+    .catch(err => expect(err).toBeUndefined())
+    .then(() => {
+      exciterAllowReject.dynamo.query.restore();
+      done();
+    });
 });
 
-test('valueIsEmpty', (done) => {
+test("valueIsEmpty", done => {
   expect.assertions(8);
 
   // Things that aren't empty.
   expect(Exciter.valueIsEmpty(1)).toEqual(false);
-  expect(Exciter.valueIsEmpty('not empty')).toEqual(false);
+  expect(Exciter.valueIsEmpty("not empty")).toEqual(false);
   expect(Exciter.valueIsEmpty([1, 2])).toEqual(false);
-  expect(Exciter.valueIsEmpty({ not: 'empty' })).toEqual(false);
+  expect(Exciter.valueIsEmpty({ not: "empty" })).toEqual(false);
 
   // Things that are empty.
   expect(Exciter.valueIsEmpty(null)).toEqual(true);
   expect(Exciter.valueIsEmpty(undefined)).toEqual(true);
-  expect(Exciter.valueIsEmpty('')).toEqual(true);
+  expect(Exciter.valueIsEmpty("")).toEqual(true);
   expect(Exciter.valueIsEmpty([])).toEqual(true);
   done();
 });

--- a/lib/Exciter.js
+++ b/lib/Exciter.js
@@ -1,11 +1,10 @@
-'use strict';
+"use strict";
 
-const aws = require('aws-sdk');
-const _ = require('lodash');
+const aws = require("aws-sdk");
+const _ = require("lodash");
 
 /** Class representing a DynamoDB connection */
 class Exciter {
-
   /**
   * @param {Object} options
   *   AWS DynamoDB.DocumentClient constructor options.
@@ -14,7 +13,9 @@ class Exciter {
   */
   constructor(options, rejectOnFail) {
     this.dynamo = new aws.DynamoDB.DocumentClient(options);
-    this.rejectOnFail = typeof rejectOnFail === 'undefined' ? true : rejectOnFail;
+    this.rejectOnFail = typeof rejectOnFail === "undefined"
+      ? true
+      : rejectOnFail;
   }
 
   /**
@@ -87,14 +88,16 @@ class Exciter {
   put(data, table, partitionKey, createOnly) {
     const payload = {
       TableName: table,
-      Item: data,
+      Item: data
     };
 
     if (createOnly) {
       payload.ConditionExpression = `attribute_not_exists(${partitionKey})`;
     }
 
-    return this.dynamo.put(payload).promise()
+    return this.dynamo
+      .put(payload)
+      .promise()
       .catch(this.catchHandler.bind(this));
   }
 
@@ -126,14 +129,22 @@ class Exciter {
         // Populate data values into an array for buildExpressionPlaceholders().
         // Do not attempt to save primaryKey values as attributes. The Key
         // property in the payload takes care of that.
-        const values = Exciter.normalizeDataValues(_.omit(data, Object.keys(primaryKey)));
+        const values = Exciter.normalizeDataValues(
+          _.omit(data, Object.keys(primaryKey))
+        );
 
         const payload = {
           TableName: table,
           Key: primaryKey,
           UpdateExpression: Exciter.buildUpdateExpression(values),
-          ExpressionAttributeNames: Exciter.buildExpressionPlaceholders(values, '#'),
-          ExpressionAttributeValues: Exciter.buildExpressionPlaceholders(values, ':'),
+          ExpressionAttributeNames: Exciter.buildExpressionPlaceholders(
+            values,
+            "#"
+          ),
+          ExpressionAttributeValues: Exciter.buildExpressionPlaceholders(
+            values,
+            ":"
+          )
         };
 
         return this.dynamo.update(payload).promise();
@@ -154,7 +165,9 @@ class Exciter {
    *   rejects if there was an error retrieving the documents.
    */
   load(primaryKey, table) {
-    return this.dynamo.get({ TableName: table, Key: primaryKey }).promise()
+    return this.dynamo
+      .get({ TableName: table, Key: primaryKey })
+      .promise()
       .catch(this.catchHandler.bind(this));
   }
 
@@ -212,7 +225,7 @@ class Exciter {
       pageForward: true,
       sortAscending: true,
       includeTotal: false,
-      startKey: null,
+      startKey: null
     });
 
     return Promise.resolve()
@@ -221,11 +234,16 @@ class Exciter {
 
         // Populate conditions and condition groups from filters.
         const filters = {};
-        ['groups', 'conditions'].forEach((array) => {
-          const type = _.trimEnd(array, 's');
+        ["groups", "conditions"].forEach(array => {
+          const type = _.trimEnd(array, "s");
           filters[array] = Object.keys(q.rawFilters)
             .filter(name => _.has(q.rawFilters[name], type))
-            .map(name => Exciter[`normalize${_.upperFirst(type)}`](q.rawFilters[name][type], name));
+            .map(name =>
+              Exciter[`normalize${_.upperFirst(type)}`](
+                q.rawFilters[name][type],
+                name
+              )
+            );
         });
 
         // Normalize and store primaryKey properties as an array of values.
@@ -240,11 +258,17 @@ class Exciter {
         // Build params to pass to the DocumentClient.
         const params = {
           KeyConditionExpression: Exciter.buildConditionExpression(keys),
-          ExpressionAttributeNames: Exciter.buildExpressionPlaceholders(values, '#'),
-          ExpressionAttributeValues: Exciter.buildExpressionPlaceholders(values, ':'),
+          ExpressionAttributeNames: Exciter.buildExpressionPlaceholders(
+            values,
+            "#"
+          ),
+          ExpressionAttributeValues: Exciter.buildExpressionPlaceholders(
+            values,
+            ":"
+          ),
           ScanIndexForward: q.sortAscending ? q.pageForward : !q.pageForward,
           TableName: table,
-          Limit: q.limit,
+          Limit: q.limit
         };
 
         // Add optional params.
@@ -253,31 +277,36 @@ class Exciter {
 
           // Build groupped expressions.
           let expressions = filters.groups.reduce((groupped, group) => {
-            const conditions = _.remove(remainingConditions, con => con.memberOf === group.name);
+            const conditions = _.remove(
+              remainingConditions,
+              con => con.memberOf === group.name
+            );
             if (conditions.length > 0) {
-              groupped.push(Exciter.buildConditionExpression(conditions, group.conjunction));
+              groupped.push(
+                Exciter.buildConditionExpression(conditions, group.conjunction)
+              );
             }
             return groupped;
           }, []);
 
-
           // Concatenate groupped conditions with ungroupped conditions.
           if (remainingConditions.length > 0) {
-            expressions = expressions.concat(Exciter.buildConditionExpression(remainingConditions));
+            expressions = expressions.concat(
+              Exciter.buildConditionExpression(remainingConditions)
+            );
           }
 
-          params.FilterExpression = expressions.join(' AND ');
+          params.FilterExpression = expressions.join(" AND ");
         }
         if (q.index) {
           params.IndexName = q.index;
         }
         if (!_.isNull(q.startKey)) {
-          if (q.startKey === 'last') {
+          if (q.startKey === "last") {
             // Reverse the scan direction.
             params.ScanIndexForward = !params.ScanIndexForward;
             retrieveTotal = true;
-          }
-          else {
+          } else {
             params.ExclusiveStartKey = q.startKey;
           }
         }
@@ -294,7 +323,7 @@ class Exciter {
 
         return Promise.all(requests);
       })
-      .then((res) => {
+      .then(res => {
         const result = _.cloneDeep(res[0]);
 
         // Get the total count from our count query.
@@ -303,16 +332,19 @@ class Exciter {
         }
 
         // If pagination is going backwards, reverse the result.
-        if (!q.pageForward || q.startKey === 'last') {
+        if (!q.pageForward || q.startKey === "last") {
           _.reverse(result.Items);
         }
 
         // If the client requested the last page, limit according to pagination
         // direction.
-        if (q.startKey === 'last') {
+        if (q.startKey === "last") {
           // Remove items which would be excluded on the last page if we didn't
           // have to reverse the scan direction to get to the last page.
-          result.Items.splice(0, result.Items.length - (result.totalCount % q.limit));
+          result.Items.splice(
+            0,
+            result.Items.length - result.totalCount % q.limit
+          );
           delete result.LastEvaluatedKey;
         }
 
@@ -340,11 +372,13 @@ class Exciter {
     // Set available id attributes.
     const payload = {
       TableName: table,
-      Key: primaryKey,
+      Key: primaryKey
     };
 
-    return this.dynamo.delete(payload).promise()
-    .catch(this.catchHandler.bind(this));
+    return this.dynamo
+      .delete(payload)
+      .promise()
+      .catch(this.catchHandler.bind(this));
   }
 
   /**
@@ -364,7 +398,7 @@ class Exciter {
     return Promise.resolve()
       .then(() => {
         let totalCount = startCount || 0;
-        const countParams = _.assign({}, params, { Select: 'COUNT' });
+        const countParams = _.assign({}, params, { Select: "COUNT" });
 
         // Do not limit count queries.
         delete countParams.Limit;
@@ -375,18 +409,17 @@ class Exciter {
           delete countParams.ExclusiveStartKey;
         }
 
-        return this.dynamo.query(countParams).promise()
-          .then((res) => {
-            totalCount += res.Count;
+        return this.dynamo.query(countParams).promise().then(res => {
+          totalCount += res.Count;
 
-            // Repeat this operation if we weren't able to count all records.
-            if (_.has(res, 'LastEvaluatedKey')) {
-              countParams.ExclusiveStartKey = res.LastEvaluatedKey;
-              return this.getTotalCount(countParams, totalCount);
-            }
+          // Repeat this operation if we weren't able to count all records.
+          if (_.has(res, "LastEvaluatedKey")) {
+            countParams.ExclusiveStartKey = res.LastEvaluatedKey;
+            return this.getTotalCount(countParams, totalCount);
+          }
 
-            return totalCount;
-          });
+          return totalCount;
+        });
       })
       .catch(this.catchHandler.bind(this));
   }
@@ -429,11 +462,13 @@ class Exciter {
    *   }
    */
   static normalizeGroup(rawGroup, name) {
-    let conjunction = 'AND';
+    let conjunction = "AND";
 
-    if (_.has(rawGroup, 'conjunction')) {
-      if (['AND', 'OR'].indexOf(rawGroup.conjunction) === -1) {
-        throw new Error(`Unsupported group conjunction: ${rawGroup.conjunction}. Allowed conjunctions: AND, OR.`);
+    if (_.has(rawGroup, "conjunction")) {
+      if (["AND", "OR"].indexOf(rawGroup.conjunction) === -1) {
+        throw new Error(
+          `Unsupported group conjunction: ${rawGroup.conjunction}. Allowed conjunctions: AND, OR.`
+        );
       }
 
       conjunction = rawGroup.conjunction;
@@ -458,8 +493,15 @@ class Exciter {
    */
   static normalizeCondition(rawCondition, name) {
     const condition = Exciter.normalizeExpressionAttribute(rawCondition, name);
-    const allowedProps = ['name', 'path', 'operator', 'value', 'memberOf', 'negate'];
-    return _.pick(_.assign({ operator: '=' }, condition), allowedProps);
+    const allowedProps = [
+      "name",
+      "path",
+      "operator",
+      "value",
+      "memberOf",
+      "negate"
+    ];
+    return _.pick(_.assign({ operator: "=" }, condition), allowedProps);
   }
 
   /**
@@ -481,11 +523,11 @@ class Exciter {
    */
   static normalizeExpressionAttribute(rawValue, name) {
     if (_.isNil(name)) {
-      throw new Error('Attribute is missing a name.');
+      throw new Error("Attribute is missing a name.");
     }
 
     let attribute = rawValue;
-    if (!_.isPlainObject(rawValue) || !_.has(rawValue, 'value')) {
+    if (!_.isPlainObject(rawValue) || !_.has(rawValue, "value")) {
       attribute = { value: rawValue };
     }
 
@@ -513,7 +555,9 @@ class Exciter {
   static normalizeDataValues(data) {
     return Object.keys(data)
       .filter(attName => !Exciter.valueIsEmpty(data[attName]))
-      .map(attName => Exciter.normalizeExpressionAttribute({ value: data[attName] }, attName));
+      .map(attName =>
+        Exciter.normalizeExpressionAttribute({ value: data[attName] }, attName)
+      );
   }
 
   /**
@@ -526,14 +570,16 @@ class Exciter {
    *   A property escaped expression for udpating DynamoDB.
    */
   static buildUpdateExpression(attributes) {
-    const exp = attributes.map((attribute) => {
-      let path = attribute.name;
-      if (_.has(attribute, 'path')) {
-        path = attribute.path.replace(/\./g, `.#${attribute.name}_`);
-        path = `${attribute.name}_${path}`;
-      }
-      return `#${path} = :${attribute.name}`;
-    }).join(', ');
+    const exp = attributes
+      .map(attribute => {
+        let path = attribute.name;
+        if (_.has(attribute, "path")) {
+          path = attribute.path.replace(/\./g, `.#${attribute.name}_`);
+          path = `${attribute.name}_${path}`;
+        }
+        return `#${path} = :${attribute.name}`;
+      })
+      .join(", ");
     return `SET ${exp}`;
   }
 
@@ -549,74 +595,86 @@ class Exciter {
    *   A property escaped expression for querying DynamoDB.
    */
   static buildConditionExpression(conditions, groupOperator) {
-    groupOperator = groupOperator || 'AND';
-    let expression = conditions.map((operation) => {
-      const condition = [];
+    groupOperator = groupOperator || "AND";
+    let expression = conditions
+      .map(operation => {
+        const condition = [];
 
-      if (operation.negate) {
-        // Negate the condition.
-        condition.push('NOT ');
-      }
-
-      // Format nested paths as DynamoDB would expect.
-      let path = operation.name;
-      if (_.has(operation, 'path')) {
-        path = operation.path.replace(/\./g, `.#${operation.name}_`);
-        path = `${operation.name}_${path}`;
-      }
-
-      // Handle simple operators.
-      if (['=', '<', '>', '<=', '>='].indexOf(operation.operator) !== -1) {
-        condition.push(`#${path} ${operation.operator} :${operation.name}`);
-      }
-      // Handle more complicated operators.
-      else {
-        // Ensure an array value for operators which require it.
-        if (['in', 'notin', 'between'].indexOf(operation.operator) !== -1
-            && (!_.isArray(operation.value) || operation.value.length < 2)
-           ) {
-          throw new Error(`Value must be an array when using the "${operation.operator}" operator.`);
+        if (operation.negate) {
+          // Negate the condition.
+          condition.push("NOT ");
         }
 
-        switch (operation.operator) {
-          case '!=': {
-            condition.push(`NOT #${path} = :${operation.name}`);
-            break;
+        // Format nested paths as DynamoDB would expect.
+        let path = operation.name;
+        if (_.has(operation, "path")) {
+          path = operation.path.replace(/\./g, `.#${operation.name}_`);
+          path = `${operation.name}_${path}`;
+        }
+
+        // Handle simple operators.
+        if (["=", "<", ">", "<=", ">="].indexOf(operation.operator) !== -1) {
+          condition.push(`#${path} ${operation.operator} :${operation.name}`);
+        } else {
+          // Handle more complicated operators.
+          // Ensure an array value for operators which require it.
+          if (
+            ["in", "notin", "between"].indexOf(operation.operator) !== -1 &&
+            (!_.isArray(operation.value) || operation.value.length < 2)
+          ) {
+            throw new Error(
+              `Value must be an array when using the "${operation.operator}" operator.`
+            );
           }
-          case 'notin': {
-            condition.push('NOT ');
-          }
-          // falls through
-          case 'in': {
-            const list = operation.value.map((val, i) => `:${operation.name}${i}`).join(', ');
-            condition.push(`#${path} IN (${list})`);
-            break;
-          }
-          case 'between': {
-            condition.push(`#${path} BETWEEN :${operation.name}0 AND :${operation.name}1`);
-            break;
-          }
-          case 'contains': {
-            condition.push(`${operation.operator}(#${path}, :${operation.name})`);
-            break;
-          }
-          case 'startswith': {
-            condition.push(`begins_with(#${path}, :${operation.name})`);
-            break;
-          }
-          case 'exists': {
-            const fun = operation.value ? 'attribute_exists' : 'attribute_not_exists';
-            condition.push(`${fun}(#${path})`);
-            break;
-          }
-          default: {
-            throw new Error(`Unsupported operator: ${operation.operator}`);
+
+          switch (operation.operator) {
+            case "!=": {
+              condition.push(`NOT #${path} = :${operation.name}`);
+              break;
+            }
+            case "notin": {
+              condition.push("NOT ");
+            }
+            // falls through
+            case "in": {
+              const list = operation.value
+                .map((val, i) => `:${operation.name}${i}`)
+                .join(", ");
+              condition.push(`#${path} IN (${list})`);
+              break;
+            }
+            case "between": {
+              condition.push(
+                `#${path} BETWEEN :${operation.name}0 AND :${operation.name}1`
+              );
+              break;
+            }
+            case "contains": {
+              condition.push(
+                `${operation.operator}(#${path}, :${operation.name})`
+              );
+              break;
+            }
+            case "startswith": {
+              condition.push(`begins_with(#${path}, :${operation.name})`);
+              break;
+            }
+            case "exists": {
+              const fun = operation.value
+                ? "attribute_exists"
+                : "attribute_not_exists";
+              condition.push(`${fun}(#${path})`);
+              break;
+            }
+            default: {
+              throw new Error(`Unsupported operator: ${operation.operator}`);
+            }
           }
         }
-      }
 
-      return `(${condition.join('')})`;
-    }).join(` ${groupOperator} `);
+        return `(${condition.join("")})`;
+      })
+      .join(` ${groupOperator} `);
 
     if (conditions.length > 1) {
       expression = `(${expression})`;
@@ -641,24 +699,25 @@ class Exciter {
   static buildExpressionPlaceholders(attributes, substitutionChar) {
     return attributes.reduce((values, attribute) => {
       // Handle names.
-      if (substitutionChar === '#') {
-        if (_.has(attribute, 'path')) {
-          attribute.path.split('.').forEach((fragment) => {
-            values[`${substitutionChar}${attribute.name}_${fragment}`] = String(fragment);
+      if (substitutionChar === "#") {
+        if (_.has(attribute, "path")) {
+          attribute.path.split(".").forEach(fragment => {
+            values[`${substitutionChar}${attribute.name}_${fragment}`] = String(
+              fragment
+            );
           });
+        } else {
+          values[`${substitutionChar}${attribute.name}`] = String(
+            attribute.name
+          );
         }
-        else {
-          values[`${substitutionChar}${attribute.name}`] = String(attribute.name);
-        }
-      }
-      // Handle array values.
-      else if (_.isArray(attribute.value)) {
+      } else if (_.isArray(attribute.value)) {
+        // Handle array values.
         attribute.value.forEach((val, i) => {
           values[`${substitutionChar}${attribute.name}${i}`] = val;
         });
-      }
-      // Handle simple values.
-      else {
+      } else {
+        // Handle simple values.
         values[`${substitutionChar}${attribute.name}`] = attribute.value;
       }
 
@@ -680,9 +739,12 @@ class Exciter {
    *   Whether or not the value is valid for DynamoDB storage.
    */
   static valueIsEmpty(value) {
-    return _.isNil(value) || value === '' || (Array.isArray(value) && value.length < 1);
+    return (
+      _.isNil(value) ||
+      value === "" ||
+      (Array.isArray(value) && value.length < 1)
+    );
   }
-
 }
 
 module.exports = Exciter;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "eslint .",
     "lint-writing": "alex",
     "write-readme": "emdaer",
-    "precommit": "yarn run lint && yarn run lint-writing",
+    "precommit": "yarn run lint && yarn run lint-writing && lint-staged",
     "prepush": "yarn run test",
     "commitmsg": "validate-commit-msg",
     "semantic-release": "semantic-release pre && semantic-release post"
@@ -41,12 +41,16 @@
     "emdaer": "^0.3.3",
     "eslint": "^3.14.1",
     "eslint-config-airbnb-base": "^11.0.1",
+    "eslint-config-prettier": "^1.7.0",
     "eslint-plugin-import": "^2.2.0",
-    "husky": "^0.13.2",
+    "eslint-plugin-prettier": "^2.0.1",
+    "husky": "^0.13.3",
     "jest": "^19.0.2",
     "jest-environment-node-debug": "^2.0.0",
+    "lint-staged": "^3.4.0",
     "mockdate": "^2.0.1",
     "nodeunit": "^0.10.2",
+    "prettier": "^1.2.2",
     "semantic-release": "^6.3.2",
     "sinon": "^2.1.0",
     "validate-commit-msg": "^2.11.2"
@@ -64,5 +68,11 @@
         "statements": 100
       }
     }
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     }
   ],
   "repository": {
-    "type": "git",
-    "url": "git://github.com:infiniteluke/exciter.git"
+    "url": "https://github.com/infiniteluke/exciter"
   },
   "scripts": {
     "test": "jest --coverage",

--- a/yarn.lock
+++ b/yarn.lock
@@ -135,7 +135,7 @@ ansi-escape-sequences@^3.0.0:
   dependencies:
     array-back "^1.0.3"
 
-ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -163,6 +163,10 @@ anymatch@^1.3.0:
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 app-usage-stats@^0.4.0:
   version "0.4.1"
@@ -322,6 +326,10 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+ast-types@0.9.8:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.8.tgz#6cb6a40beba31f49f20928e28439fc14a3dab078"
+
 async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -362,7 +370,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
+babel-code-frame@6.22.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -505,6 +513,10 @@ babel-types@^6.18.0, babel-types@^6.24.1:
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
+
+babylon@7.0.0-beta.8:
+  version "7.0.0-beta.8"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.8.tgz#2bdc5ae366041442c27e068cce6f0d7c06ea9949"
 
 babylon@^6.11.0, babylon@^6.13.0, babylon@^6.15.0:
   version "6.16.1"
@@ -694,7 +706,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@1.1.3, chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -741,11 +753,22 @@ cli-commands@0.1.0:
     command-line-commands "^1.0.4"
     command-line-usage "^3.0.5"
 
-cli-cursor@^1.0.1:
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
     restore-cursor "^1.0.1"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -1004,6 +1027,19 @@ core-util-is@^1.0.1, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.0.1"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    pinkie-promise "^2.0.0"
+    require-from-string "^1.1.0"
+
 coveralls@^2.11.2:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-2.13.0.tgz#df933876e8c6f478efb04f4d3ab70dc96b7e5a8e"
@@ -1025,6 +1061,14 @@ cross-spawn@^4:
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -1068,6 +1112,10 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.27.2:
+  version "1.28.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.3.tgz#145d87adc3f5a82c6bda668de97eee1132c97ea1"
 
 dateformat@^1.0.11:
   version "1.0.12"
@@ -1229,6 +1277,10 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
+
 emdaer@^0.3.3:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/emdaer/-/emdaer-0.3.3.tgz#ee0ef1553bcb75e62b84c94fe086ced873d3adc6"
@@ -1334,6 +1386,12 @@ eslint-config-airbnb-base@^11.0.1:
   version "11.1.3"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.1.3.tgz#0e8db71514fa36b977fbcf977c01edcf863e0cf0"
 
+eslint-config-prettier@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-1.7.0.tgz#cda3ce22df1e852daa9370f1f3446e8b8a02ce44"
+  dependencies:
+    get-stdin "^5.0.1"
+
 eslint-import-resolver-node@^0.2.0:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
@@ -1363,6 +1421,12 @@ eslint-plugin-import@^2.2.0:
     lodash.cond "^4.3.0"
     minimatch "^3.0.3"
     pkg-up "^1.0.0"
+
+eslint-plugin-prettier@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.0.1.tgz#2ae1216cf053dd728360ca8560bf1aabc8af3fa9"
+  dependencies:
+    requireindex "~1.1.0"
 
 eslint@^3.14.1:
   version "3.19.0"
@@ -1451,7 +1515,7 @@ estraverse@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.1.1.tgz#f6caca728933a850ef90661d0e17982ba47111a2"
 
-esutils@^2.0.2:
+esutils@2.0.2, esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
@@ -1495,6 +1559,18 @@ exec-sh@^0.2.0:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.2.0.tgz#14f75de3f20d286ef933099b2ce50a90359cef10"
   dependencies:
     merge "^1.1.3"
+
+execa@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.6.3.tgz#57b69a594f081759c69e5370f0d17b9cb11658fe"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -1548,7 +1624,7 @@ feature-detect-es6@^1.2.0, feature-detect-es6@^1.3.0, feature-detect-es6@^1.3.1:
   dependencies:
     array-back "^1.0.3"
 
-figures@^1.3.5:
+figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -1663,6 +1739,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+flow-parser@0.43.0:
+  version "0.43.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.43.0.tgz#e2b8eb1ac83dd53f7b6b04a7c35b6a52c33479b7"
+
 fn-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
@@ -1776,9 +1856,17 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
+get-stdin@5.0.1, get-stdin@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
 get-stdin@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.6"
@@ -1850,16 +1938,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^4:
-  version "4.5.3"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
-  dependencies:
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^2.0.1"
-    once "^1.3.0"
-
-glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0:
+glob@7.1.1, glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -1869,6 +1948,15 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.0:
     minimatch "^3.0.2"
     once "^1.3.0"
     path-is-absolute "^1.0.0"
+
+glob@^4:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-4.5.3.tgz#c6cb73d3226c1efef04de3c56d012f03377ee15f"
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^2.0.1"
+    once "^1.3.0"
 
 globals@^9.0.0, globals@^9.14.0:
   version "9.17.0"
@@ -2052,7 +2140,7 @@ https-proxy-agent@^1.0.0:
     debug "2"
     extend "3"
 
-husky@^0.13.2:
+husky@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.13.3.tgz#bc2066080badc8b8fe3516e881f5bc68a57052ff"
   dependencies:
@@ -2082,6 +2170,10 @@ indent-string@^2.1.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
   dependencies:
     repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
 
 index-of@^0.1.1:
   version "0.1.1"
@@ -2268,6 +2360,10 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -2286,7 +2382,7 @@ is-retry-allowed@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
-is-stream@^1.0.0:
+is-stream@^1.0.0, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -2585,6 +2681,15 @@ jest-util@^19.0.2:
     leven "^2.0.0"
     mkdirp "^0.5.1"
 
+jest-validate@19.0.0:
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.0.tgz#8c6318a20ecfeaba0ba5378bfbb8277abded4173"
+  dependencies:
+    chalk "^1.1.1"
+    jest-matcher-utils "^19.0.0"
+    leven "^2.0.0"
+    pretty-format "^19.0.0"
+
 jest-validate@^19.0.2:
   version "19.0.2"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-19.0.2.tgz#dc534df5f1278d5b63df32b14241d4dbf7244c0c"
@@ -2621,7 +2726,7 @@ js-yaml@3.6.1:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.2.7, js-yaml@^3.3.1, js-yaml@^3.5.1, js-yaml@^3.6.1, js-yaml@^3.7.0:
+js-yaml@^3.2.7, js-yaml@^3.3.1, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.6.1, js-yaml@^3.7.0:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.3.tgz#33a05ec481c850c8875929166fe1beb61c728766"
   dependencies:
@@ -2826,6 +2931,64 @@ limit-spawn@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/limit-spawn/-/limit-spawn-0.0.3.tgz#cc09c24467a0f0a1ed10a5196dba597cad3f65dc"
 
+lint-staged@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-3.4.0.tgz#52fa85dfc92bb1c6fe8ad0d0d98ca13924e03e4b"
+  dependencies:
+    app-root-path "^2.0.0"
+    cosmiconfig "^1.1.0"
+    execa "^0.6.0"
+    listr "^0.11.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    staged-git-files "0.0.4"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/listr/-/listr-0.11.0.tgz#5e778bc23806ac3ab984ed75564458151f39b03e"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2954,6 +3117,13 @@ log-symbols@^1.0.2:
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
   dependencies:
     chalk "^1.0.0"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
 
 lolex@^1.6.0:
   version "1.6.0"
@@ -3252,6 +3422,12 @@ normalize-path@^2.0.1:
     hosted-git-info "^2.1.5"
     semver "^5.1.0"
 
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
+
 npm-prefix@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/npm-prefix/-/npm-prefix-1.2.0.tgz#e619455f7074ba54cc66d6d0d37dd9f1be6bcbc0"
@@ -3275,6 +3451,20 @@ npm-registry-client@^7.0.1:
     slide "^1.1.3"
   optionalDependencies:
     npmlog "2 || ^3.1.0 || ^4.0.0"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmconf@^2.1.2:
   version "2.1.2"
@@ -3441,6 +3631,15 @@ optionator@^0.8.1, optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 os-homedir@1.0.1, os-homedir@^1.0.0, os-homedir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.1.tgz#0d62bdf44b916fd3bbdcf2cab191948fb094f007"
@@ -3461,6 +3660,10 @@ osenv@^0.1.0, osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.1.0:
   version "1.1.0"
@@ -3551,6 +3754,10 @@ path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
 
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
 path-object@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/path-object/-/path-object-2.3.0.tgz#03e46653e5c375c60af1cabdd94bc6448a5d9110"
@@ -3629,6 +3836,21 @@ prepend-http@^1.0.1:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+prettier@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.2.2.tgz#22d17c1132faaaea1f1d4faea31f19f7a1959f3e"
+  dependencies:
+    ast-types "0.9.8"
+    babel-code-frame "6.22.0"
+    babylon "7.0.0-beta.8"
+    chalk "1.1.3"
+    esutils "2.0.2"
+    flow-parser "0.43.0"
+    get-stdin "5.0.1"
+    glob "7.1.1"
+    jest-validate "19.0.0"
+    minimist "1.2.0"
 
 pretty-format@^19.0.0:
   version "19.0.0"
@@ -3980,6 +4202,10 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
 
+require-from-string@^1.1.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-1.2.1.tgz#529c9ccef27380adfec9a2f965b649bbee636418"
+
 require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
@@ -3994,6 +4220,10 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
 requizzle@~0.2.1:
   version "0.2.1"
@@ -4094,6 +4324,12 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
+rxjs@^5.0.0-beta.11:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.3.0.tgz#d88ccbdd46af290cbdb97d5d8055e52453fabe2d"
+  dependencies:
+    symbol-observable "^1.0.1"
+
 samsam@1.x, samsam@^1.1.3:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/samsam/-/samsam-1.2.1.tgz#edd39093a3184370cb859243b2bdf255e7d8ea67"
@@ -4162,6 +4398,16 @@ semver@~5.0.1:
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@^0.7.5:
   version "0.7.7"
@@ -4333,6 +4579,10 @@ stack-utils@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-0.4.0.tgz#940cb82fccfa84e8ff2f3fdf293fe78016beccd1"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
 state-toggle@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
@@ -4363,6 +4613,10 @@ stream-handlebars@~0.1.6:
   dependencies:
     handlebars "^3.0.0"
     object-tools "^1.2.1"
+
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
 
 stream-via@^1.0.3:
   version "1.0.3"
@@ -4431,6 +4685,10 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
 strip-indent@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
@@ -4450,6 +4708,10 @@ supports-color@^3.1.2:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
   dependencies:
     has-flag "^1.0.0"
+
+symbol-observable@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
 symbol-tree@^3.2.1:
   version "3.2.2"
@@ -5019,7 +5281,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.1.1, which@^1.2.12, which@^1.2.4, which@^1.2.9:
+which@^1.1.1, which@^1.2.10, which@^1.2.12, which@^1.2.4, which@^1.2.9:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:


### PR DESCRIPTION
This allows us to not care about style as we're developing. Prettier will take care of enforcing consistent style via the `precommit` hook that fixes stages files. This PR also introduces the plugin for  ignoring other eslint rules that have style opinions (airbnb-base) and removes our custom overrides that were style related.