### PR TITLE
Optionally add `if exists` condition to delete request

### DIFF
--- a/lib/Exciter.js
+++ b/lib/Exciter.js
@@ -357,18 +357,30 @@ class Exciter {
    *   partitionKey and sortKey.
    * @param {String} table
    *   The table from which to delete the document.
+   * @param {Boolean} expectToExist
+   *   Whether the operation should only succeed if the record exists.
    *
    * @return {Promise}
    *   Resolves when the documents have been written to DynamoDB,
    *   rejects if there was an error either opening the documents or writing
    *   to DynamoDB.
    */
-  delete(primaryKey, table) {
+  delete(primaryKey, table, expectToExist) {
     // Set available id attributes.
     const payload = {
       TableName: table,
       Key: primaryKey,
     };
+
+    if (expectToExist) {
+      payload.ConditionExpression = Object.keys(primaryKey)
+        .map(name => `attribute_exists(#${name})`)
+        .join(' AND ');
+      payload.ExpressionAttributeNames = Exciter.buildExpressionPlaceholders(
+        Exciter.normalizeDataValues(primaryKey),
+        '#'
+      );
+    }
 
     return this.dynamo.delete(payload).promise()
     .catch(this.catchHandler.bind(this));


### PR DESCRIPTION
I found that I cannot use `exciter` to make a simple RESTful delete endpoint which returns `404` if the resource does not exist.

There are different opinions on the topic, what status code to return in such a case, so it makes sense for `exciter` to make both possible.

This PR allows to add a third parameter `expectToExist` to `exciter.delete()`. If it is set to true, a `ConditionalCheckFailedException` will be thrown if the resource did not exists. This way, one can use the information, that the resource did not exist, which can particularly be used to return `404` on a http request.

This extends - not modifies - this module's behavior.